### PR TITLE
Upgrade example to Java 11, Spring Boot 2.7.2, JUnit 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ target/
 *.iws
 .vscode
 .history
+.dccache
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM openjdk:8u111-jre-alpine
-RUN apk add --no-cache bash
+FROM amazoncorretto:11
+USER 1000
 VOLUME /tmp
-ADD target/mobile-deposit-api-*.jar app.jar
-RUN bash -c 'touch /app.jar'
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+COPY target/mobile-deposit-api-*.jar app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ metadata:
 spec:
   containers:
   - name: maven
-    image: maven:3.6.1-jdk-8-slim
+    image: maven:3.8.6-jdk-11-slim
     command:
     - cat
     tty: true

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,13 @@
 
     <groupId>com.cloudbees.example.mobile.api</groupId>
     <artifactId>mobile-deposit-api</artifactId>
-    <version>0.0.19-SNAPSHOT</version>
+    <version>0.1</version>
     <name>Mobile Deposit API</name>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.2.RELEASE</version>
+        <version>2.7.2</version>
     </parent>
 
     <licenses>
@@ -30,10 +30,7 @@
     </developers>
 
     <properties>
-        <java.version>1.8</java.version>
-        <project.scm.id>github</project.scm.id>
-
-        <spock.version>1.1</spock.version>
+        <java.version>11</java.version>
     </properties>
 
     <dependencies>
@@ -58,30 +55,9 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <artifactId>maven-resources-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>copy-resources</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${basedir}/target/</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>.docker</directory>
-                                    <filtering>true</filtering>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.3</version>
+                <version>0.8.8</version>
                 <configuration>
                     <append>true</append>
                 </configuration>
@@ -107,76 +83,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
-                <configuration>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <useReleaseProfile>false</useReleaseProfile>
-                    <releaseProfiles>release</releaseProfiles>
-                    <tagNameFormat>@{project.version}</tagNameFormat>
-                    <goals>deploy</goals>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.scm</groupId>
-                        <artifactId>maven-scm-provider-gitexe</artifactId>
-                        <version>1.8.1</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>3.0.1</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.0.1</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>de.jutzig</groupId>
-                        <artifactId>github-release-plugin</artifactId>
-                        <version>1.3.0</version>
-                        <executions>
-                            <execution>
-                                <id>github-upload</id>
-                                <phase>deploy</phase>
-                                <goals>
-                                    <goal>release</goal>
-                                </goals>
-                                <inherited>false</inherited>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
 </project>

--- a/src/main/java/com/cloudbees/example/mobile/deposit/api/DepositEndpoint.java
+++ b/src/main/java/com/cloudbees/example/mobile/deposit/api/DepositEndpoint.java
@@ -2,7 +2,6 @@ package com.cloudbees.example.mobile.deposit.api;
 
 import com.cloudbees.example.mobile.deposit.api.model.Deposit;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,7 +17,6 @@ public class DepositEndpoint {
     @Value("${version}")
     private String version;
 
-    @CrossOrigin(origins = "*")
     @GetMapping("/account/deposit")
     public @ResponseBody Deposit getDepositAccount() {
 

--- a/src/test/java/com/cloudbees/example/mobile/deposit/api/DepositEndpointTests.java
+++ b/src/test/java/com/cloudbees/example/mobile/deposit/api/DepositEndpointTests.java
@@ -1,19 +1,16 @@
 package com.cloudbees.example.mobile.deposit.api;
 
 import com.cloudbees.example.mobile.deposit.api.model.Deposit;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = MobileDepositApplication.class, webEnvironment=RANDOM_PORT)
 public class DepositEndpointTests {
 
@@ -31,7 +28,5 @@ public class DepositEndpointTests {
 
         Deposit deposit = entity.getBody();
         assertEquals("Free Checking", deposit.getName());
-
     }
-
 }


### PR DESCRIPTION
OpenJDK docker images are now deprecated. Ideally we would use those from Amazon, though note the alpine distributions are not yet available for Apple M1, so using their standard amazoncorretto image based on amazon linux for now so that it works on each of our laptops.